### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ terminado==0.8.1
 testpath==0.3.1
 toolz==0.9.0
 tornado==5.1
-tqdm==4.26.0
+tqdm>=4.36.0
 traitlets==4.3.2
 typed-ast==1.1.0
 urllib3==1.24.2


### PR DESCRIPTION
New import syntax language in imports_ipython ("import tqdm.notebook") only valid with more recent tqdm module naming (related to [#360](https://github.com/HazyResearch/fonduer/issues/360)).